### PR TITLE
Don't try to backup frozen sites.

### DIFF
--- a/pan-sandbox-backups.sh
+++ b/pan-sandbox-backups.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 terminus auth:login --machine-token="${TERMINUS_TOKEN}"
 
-for site in $(terminus org:site:list "${PANTHEON_ORG_ID}" --tag=backups-bot --field=Name --format=list)
+for site in $(terminus org:site:list "${PANTHEON_ORG_ID}" --tag=backups-bot --filter="frozen!=1" --field=Name --format=list)
 do
     echo "Creating backups for ${site}..."
     for env in $(terminus env:list "$site" --filter='initialized=1' --field=ID)


### PR DESCRIPTION
Hitting a frozen site caused the script to exit. We can just skip these.